### PR TITLE
SFET-82 Add support for is_implicit query param

### DIFF
--- a/lib/Checkout.php
+++ b/lib/Checkout.php
@@ -18,6 +18,10 @@ abstract class Checkout
         $msg = "{$option} is missing.";
         throw new Exception\UnexpectedValueException($msg);
       }
+      if (isset($options["is_implicit"]) && $options["is_implicit"] !== "true") {
+        $msg = "to use is_implicit, the value must be a string and set to true";
+        throw new Exception\UnexpectedValueException($msg);
+      }
     }
   }
 
@@ -36,6 +40,10 @@ abstract class Checkout
    * Optional parameters are
    * 1. `source`: Either 'mobile' if you are rendering in a mobile webview or 'custom'
    * 2. `address`: The Address ID if you wish to prefil the customer's billing address.
+   * 3. `is_implicit`: To make card saving mandatory. Instead of a checkbox to confirm 
+   * whether to save the card or not, the customer is shown a disclaimer saying that their
+   * card will be saved for all future charges. This must be set to a string with value "true" 
+   * to be used.
    * @throws Exception\UnexpectedValueException if the payload is not valid JSON,
    *
    * @return string the Checkout URL
@@ -64,6 +72,10 @@ abstract class Checkout
 
     if (isset($options["address"])) {
       $params["address"] = $options["address"];
+    }
+
+    if (isset($options["is_implicit"])) {
+      $params["is_implicit"] = $options["is_implicit"];
     }
 
     $encoded = \http_build_query($params);


### PR DESCRIPTION
# Description

Allows using the new `is_implicit` query param when generating the checkout URL

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Description

1. **What is the current behavior?** (You can also link to an open issue here)
Related to this [task](https://www.notion.so/safepay/Engineering-164ccc2f14984a1793329e6cec698fd6?v=c148f333ccc54acb8b0345aece7ba770&p=a9fb8c50fec147f488b4866574dfaaa1&pm=s)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
