### PR TITLE
SFET-203: [fix] Checkout environment query param

### DIFF
--- a/lib/Checkout.php
+++ b/lib/Checkout.php
@@ -63,7 +63,7 @@ abstract class Checkout
     }
 
     $params = array(
-      "env" => $env,
+      "environment" => $env,
       "tracker" => $options["tracker"],
       "source" => $options["source"] ?? "custom",
       "tbt" => $options["tbt"],


### PR DESCRIPTION
# Description
Fixes the query param for the environment. Changes it from `env` to `environment`
