### PR TITLE
Q324-ET-24: [subscriptions] Fix reference addition

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Configure your Safepay API key and secret inside `secrets.php`. You may find the
 - Run `php -S 127.0.0.1:8000`
 - Navigate to [localhost:8000](http://localhost:8000) on your browser
 
-## Examples
+## Examples: Customers
 
 ### Customers and Payment Methods
 
@@ -36,3 +36,15 @@ Code: [customers-instrument.php](/public/customers-instrument.php)
 Perform a charge on your customer's behalf using a payment method from their wallet.
 
 Code: [customers-payment.php](/public/customers-payment.php)
+
+## Examples: Subscriptions
+
+### Subscribe to a plan with the Subscriptions Checkout
+
+Safepay supports native subscriptions by allowing a customer to subscribe to a plan. In order for this to happen, your system will need to generate a secure URL to which the customer must be redirected to in order to complete the subscription.
+
+Safepay has created a secure, hosted page to collect sensitive information from your customer and allow them to subscribe to your plan. The code below shows how you can generate a Subscriptions Checkout URL through which your customer can subscribe to your plan.
+
+The code in this example may be triggered from the UI to generate a subscriptions checkout URL.
+
+Code: [subscriptions-checkout.php](/public/subscriptions-checkout.php)

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "getsafepay/sfpy-php": "^0.0.11"
+        "getsafepay/sfpy-php": "^0.0.12"
     }
 }

--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -19,11 +19,11 @@
     <section>
       <div class="product">
         <div class="description">
-          <h3>Customers: Create a payment</h3>
+          <h3>Subscriptions: Subscribe to a plan</h3>
         </div>
       </div>
-      <form action="/customers-payment-cof.php" method="POST">
-        <button type="submit" id="customer-payment-button">See Demo</button>
+      <form action="/subscriptions-checkout.php" method="POST">
+        <button type="submit" id="subscriptions-button">See Demo</button>
       </form>
     </section>
 

--- a/examples/public/subscriptions-checkout.php
+++ b/examples/public/subscriptions-checkout.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Subscriptions: Subscribe to a plan
+ * ------------------------------------
+ * 
+ * Safepay supports native subscriptions by allowing a customer to subscribe
+ * to a plan. In order for this to happen, your system will need to generate
+ * a secure URL to which the customer must be redirected to in order to complete
+ * the subscription.
+ * 
+ * Safepay has created a secure, hosted page to collect sensitive information
+ * from your customer and allow them to subscribe to your plan. The code below
+ * shows how you can generate a Subscriptions Checkout URL through which your
+ * customer can subscribe to your plan.
+ */
+
+require_once '../vendor/autoload.php';
+require_once '../secrets.php';
+
+$safepay = new \Safepay\SafepayClient([
+  'api_key' => $safepaySecretKey,
+  'api_base' => 'https://sandbox.api.getsafepay.com'
+]);
+
+header('Content-Type: application/json');
+
+try {
+  // Change this ID to reflect the ID of the Plan you have created
+  // either through the merchant dashboard or through the API.
+  $plan_id = "plan_1d94acdb-a9cd-4cc2-972b-0e2264b1388c";
+
+  // You need to create a Time Based Authentication token
+  $tbt = $safepay->passport->create();
+
+  // To ease reconciliation, you may associate a reference
+  // that you generate in your system. This will be returned
+  // in webhooks received when the subscription is created.
+  $reference = "0950fa13-1a28-4529-80bf-89f6f4e830a5";
+
+  // Finally, you can create the Subscribe URL
+  $subscribeURL = \Safepay\SubscriptionsCheckout::constructURL([
+      "environment" => "sandbox",
+      "plan_id" => $plan_id,
+      "tbt" => $tbt->token,
+      // "reference" => $reference,
+      "cancel_url" => "https://mywebiste.com/subscribe/cancel",
+      "redirect_url" => "https://mywebiste.com/subscribe/success",
+  ]);
+
+  echo($subscribeURL);
+} catch(\UnexpectedValueException $e) {
+  // Invalid payload
+  http_response_code(400);
+  exit();
+}

--- a/lib/SubscriptionsCheckout.php
+++ b/lib/SubscriptionsCheckout.php
@@ -54,15 +54,19 @@ abstract class SubscriptionsCheckout
     } else {
       $baseURL = self::PROD_BASE_URL;
     }
-
+    
     $params = array(
       "env" => $env,
       "plan_id" => $options["plan_id"],
       "auth_token" => $options["tbt"],
-      "reference" => $options["reference"],
       "cancel_url" => $options["cancel_url"],
       "redirect_url" => $options["redirect_url"],
     );
+
+    // Add reference if present
+    if (isset($options["reference"])) {
+      $params["reference"] = $options["reference"]; 
+    }
 
     $encoded = \http_build_query($params);
     return $baseURL . "/subscribe?" . $encoded;


### PR DESCRIPTION
# Description
Fixes an issue with subscriptions checkout URL generation when the `reference` is missing. This should be optional.
