### PR TITLE
Q324-ET-24: [fix] Customers cof payment example

### DIFF
--- a/examples/public/customers-payment-cof.php
+++ b/examples/public/customers-payment-cof.php
@@ -172,6 +172,4 @@ $tracker = $safepay->order->charge($session->tracker->token, [
   instead would call the `charge` method with an empty payload to
   capture the payment.
 */ 
-$tracker = $safepay->order->charge($session->tracker->token, [
-  "payload" => []
-]);
+$tracker = $safepay->order->charge($session->tracker->token, new stdClass());


### PR DESCRIPTION
# Description
Correctly send empty payload for capture in customers cof payment example
