### PR TITLE
payments: fix checkout redirection urls

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "getsafepay/sfpy-php": "^0.0.14"
+        "getsafepay/sfpy-php": "^0.0.15"
     }
 }

--- a/examples/public/checkout.php
+++ b/examples/public/checkout.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Create a Checkout session
+ * ------------------------------------
+ * 
+ * This example shows how you can create a new Checkout session
+ * to accept payments from your customers.
+ * 
+ * The code in this example may be triggered from the UI.
+ */
+
+/* 
+  Instantiate the Safepay PHP SDK by passing in your 
+  API Secret Key and the appropriate base URL to target
+  Options for Base URL are:
+  1. 'https://dev.api.getsafepay.com' (development environment for beta features)
+  2. 'https://sandbox.api.getsafepay.com' (sandbox environment for stable features)
+  3. 'https://api.getsafepay.com' (production/live environment)
+*/
+
+require_once '../vendor/autoload.php';
+require_once '../secrets.php';
+
+$safepay = new \Safepay\SafepayClient([
+  'api_key' => $safepaySecretKey,
+  'api_base' => 'https://sandbox.api.getsafepay.com'
+]);
+
+
+header('Content-Type: application/json');
+
+try {
+  // You need to generate a tracker with mode 'payment'
+  // to tell Safepay that you wish to set up a tracker to
+  // accept a payment from your customer.
+  $session = $safepay->order->setup([
+    "merchant_api_key" => $safepayAPIKey,
+    "intent" => "CYBERSOURCE",
+    "mode" => "payment",
+    "currency" => "PKR",
+    "amount" => 10000 // In minor units of the currency e.g. in paisas
+  ]);
+
+  // Optional. You may create an address object if you have
+  // access to the customer's billing details. If not, the
+  // customer will be prompted to enter their address details
+  // on the checkout UI.
+  $address = $safepay->address->create([
+    // Required
+    "street1" => "3A-2 7th South Street",
+    "city" => "Karachi",
+    "country" => "PK",
+    
+    // Optional
+    "postal_code" => "75500",
+    "state" => "Sindh"
+  ]);
+
+  // You need to create a Time Based Authentication token for the checkout session.
+  $tbt = $safepay->passport->create();
+
+  // Finally, you can create the Checkout URL
+  $checkoutURL = \Safepay\Checkout::constructURL([
+    "environment" => "sandbox", // one of "development", "sandbox" or "production"
+    "tracker" => $session->tracker->token,
+    "tbt" => $tbt->token,
+    "customer" => "cus_nfsdknfjiasdnfasdf",
+    "cancel_url" => "https://example.com",
+    "redirect_url" => "https://www.google.com",
+    //"address" => $address->token, // If you wish to save the customer from having to enter their address details
+    "source" => "mobile" // Important for rendering in a mobile WebView but you may enter "custom" otherwise
+  ]);
+  echo ($checkoutURL);
+  return $checkoutURL;
+} catch (\Safepay\Exception\InvalidRequestException $e) {
+  echo 'Status is:' . $e->getHttpStatus() . '\n';
+  echo 'Message is:' . $e->getError() . '\n';
+} catch (\Safepay\Exception\AuthenticationException $e) {
+  echo 'Status is:' . $e->getHttpStatus() . '\n';
+  echo 'Message is:' . $e->getError() . '\n';
+} catch (\Safepay\Exception\UnknownApiErrorException $e) {
+  echo 'Status is:' . $e->getHttpStatus() . '\n';
+  echo 'Message is:' . $e->getError() . '\n';
+} catch (Exception $e) {
+  // Something else happened, completely unrelated to Safepay
+  print_r($e);
+}

--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -8,6 +8,17 @@
     <section>
       <div class="product">
         <div class="description">
+          <h3>Payments: Create a checkout session</h3>
+        </div>
+      </div>
+      <form action="/checkout.php" method="POST">
+        <button type="submit" id="checkout-button">See Demo</button>
+      </form>
+    </section>
+
+    <section>
+      <div class="product">
+        <div class="description">
           <h3>Customers: Save a new payment method</h3>
         </div>
       </div>

--- a/lib/Checkout.php
+++ b/lib/Checkout.php
@@ -34,13 +34,13 @@ abstract class Checkout
    * Supported parameters that are required are
    * 1. `tracker`: The Tracker ID that is generated
    * 2. `environment`: One of 'development', 'sandbox' or 'production'
-   * 3. `user_id`: The Customer ID that represents the customer making the purchase
-   * 4. `tbt`: The Time Based Authentication token
+   * 3. `tbt`: The Time Based Authentication token
    * 
    * Optional parameters are
    * 1. `source`: Either 'mobile' if you are rendering in a mobile webview or 'custom'
    * 2. `address`: The Address ID if you wish to prefil the customer's billing address.
-   * 3. `is_implicit`: To make card saving mandatory. Instead of a checkbox to confirm 
+   * 3. `user_id`: The Customer ID that represents the customer making the purchase
+   * 4. `is_implicit`: To make card saving mandatory. Instead of a checkbox to confirm 
    * whether to save the card or not, the customer is shown a disclaimer saying that their
    * card will be saved for all future charges. This must be set to a string with value "true" 
    * to be used.
@@ -67,11 +67,22 @@ abstract class Checkout
       "tracker" => $options["tracker"],
       "source" => $options["source"] ?? "custom",
       "tbt" => $options["tbt"],
-      "user_id" => $options["customer"]
     );
 
+    // Set customer and address if available
+    if (isset($options["customer"])) {
+      $params["user_id"] = $options["customer"];
+    }
     if (isset($options["address"])) {
       $params["address"] = $options["address"];
+    }
+
+    // Set redirection URLs if available
+    if (isset($options["redirect_url"])) {
+      $params["redirect_url"] = $options["redirect_url"];
+    }
+    if (isset($options["cancel_url"])) {
+      $params["cancel_url"] = $options["cancel_url"];
     }
 
     if (isset($options["is_implicit"])) {


### PR DESCRIPTION
# Description
Changes for checkout integration
- Adds support for the `redirect_url` and `cancel_url`
- Makes `customer` optional
- Adds example for creating a payments checkout session