### PR TITLE
Q324-ET-171: Payments checkout example now uses the hosted source

### DIFF
--- a/examples/public/checkout.php
+++ b/examples/public/checkout.php
@@ -65,7 +65,7 @@ try {
     "environment" => "sandbox", // one of "development", "sandbox" or "production"
     "tracker" => $session->tracker->token,
     "tbt" => $tbt->token,
-    "source" => "woocommerce", // This triggers redirection but will eventually be replaced with a more appropriate value
+    "source" => "hosted",
     "cancel_url" => "https://example.com",
     "redirect_url" => "https://example.com",
 


### PR DESCRIPTION
# Description
The payments checkout example uses the `hosted` source to enable redirection.